### PR TITLE
Raw cli cleanup

### DIFF
--- a/datacenter/backbone/group_vars/BACKBONE.yml
+++ b/datacenter/backbone/group_vars/BACKBONE.yml
@@ -10,8 +10,7 @@ backbone:
     platform: vEOS-lab
     loopback_ipv4_pool: 1.1.0.0/24
     bgp_as: 65500
-    raw_eos_cli: |
-      agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP='true'
+    
   nodes: 
     - name: BB1
       id: 1 

--- a/datacenter/domain-a/group_vars/DOMAIN_A.yml
+++ b/datacenter/domain-a/group_vars/DOMAIN_A.yml
@@ -52,9 +52,6 @@ l3leaf:
       spanning_tree:
         edge_port:
           bpduguard_default: true
-    # can remove agent KernelFib command, not in tech library
-    raw_eos_cli: |
-      agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP='true'
   node_groups: 
     - group: DOMAIN_A_LA
       bgp_as: 65112

--- a/datacenter/domain-a/group_vars/DOMAIN_A_L3_LEAVES.yml
+++ b/datacenter/domain-a/group_vars/DOMAIN_A_L3_LEAVES.yml
@@ -3,6 +3,7 @@ type: l3leaf
 
 dhcp_relay:
   tunnel_requests_disabled: true
+  mlag_peerlink_requests_disabled: true
 
 # variables used in custom templates
 ## _ prefix = bypass avd schema validation

--- a/datacenter/domain-a/group_vars/FABRIC.yml
+++ b/datacenter/domain-a/group_vars/FABRIC.yml
@@ -4,8 +4,8 @@ fabric_name: FABRIC
 underlay_routing_protocol: ebgp
 overlay_routing_protocol: ebgp
 
-# underlay_multicast: true
-# evpn_multicast: true
+underlay_multicast: true
+evpn_multicast: true
 
 fabric_ip_addressing:
   mlag:

--- a/datacenter/domain-b/group_vars/DOMAIN_B.yml
+++ b/datacenter/domain-b/group_vars/DOMAIN_B.yml
@@ -140,10 +140,6 @@ l3leaf:
           - hostname: BB2
             bgp_as: 65500
             ip_address: 1.1.0.2
-      raw_eos_cli: |
-        dhcp relay
-          mlag peer-link requests disabled
-        agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP='true'
       nodes:
         - name: B-LEAF7
           id: 7

--- a/datacenter/domain-b/group_vars/DOMAIN_B_L3_LEAVES.yml
+++ b/datacenter/domain-b/group_vars/DOMAIN_B_L3_LEAVES.yml
@@ -3,16 +3,16 @@ type: l3leaf
 
 
 cv_tags_topology_type: leaf
-#evpn_multicast: true
+evpn_multicast: true
 
 dhcp_relay:
   tunnel_requests_disabled: true
 
 # variables used in custom templates
-# _prod_multicast_group_overlay: 239.0.20.101
-# _prod_multicast_group_encap: 232.1.1.20
+_prod_multicast_group_overlay: 239.0.20.101
+_prod_multicast_group_encap: 232.1.1.20
 
-# _dev_multicast_group_overlay: 239.0.60.101
-# _dev_multicast_group_encap: 232.2.2.60
+_dev_multicast_group_overlay: 239.0.60.101
+_dev_multicast_group_encap: 232.2.2.60
 
 _evpn_aa_multihoming: true

--- a/datacenter/domain-c/group_vars/DOMAIN_C.yml
+++ b/datacenter/domain-c/group_vars/DOMAIN_C.yml
@@ -9,10 +9,8 @@ spine:
     loopback_ipv4_pool: 1.1.3.0/24
     vtep_loopback_ipv4_pool: 10.3.3.0/24
     virtual_router_mac_address: 00:1c:73:00:00:01 
-    bgp_as: 65300
-    raw_eos_cli: |
-      agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP='true'
-  nodes: 
+    bgp_as: 65300  nodes:
+
     - name: C-SPINE1
       id: 201 
       mgmt_ip: 192.168.0.19/24 
@@ -46,10 +44,6 @@ l3leaf:
       spanning_tree:
         edge_port:
           bpduguard_default: true
-    raw_eos_cli: |
-      dhcp relay
-        mlag peer-link requests disabled
-      agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP='true'
   node_groups: 
     - group: DOMAIN_C_LA
       bgp_as: 65312

--- a/datacenter/domain-c/group_vars/DOMAIN_C_EVPNGW.yml
+++ b/datacenter/domain-c/group_vars/DOMAIN_C_EVPNGW.yml
@@ -29,10 +29,6 @@ csc_route_maps:
         match:
           - 'ip address prefix-list PL-GATEWAY-LOOP'
 
-# csc_vlan_interfaces:
-#   - name: 'Vlan4094'
-#     mtu: 1500
-
 monitor_connectivity:
   shutdown: false
   vrfs:

--- a/datacenter/domain-c/group_vars/DOMAIN_C_L3_LEAVES.yml
+++ b/datacenter/domain-c/group_vars/DOMAIN_C_L3_LEAVES.yml
@@ -3,6 +3,7 @@ type: l3leaf
 
 dhcp_relay:
   tunnel_requests_disabled: true
+  mlag_peerlink_requests_disabled: true
 
 csc_vlan_interfaces:
   - name: 'Vlan4094'

--- a/datacenter/domain-c/group_vars/FABRIC.yml
+++ b/datacenter/domain-c/group_vars/FABRIC.yml
@@ -6,8 +6,8 @@ overlay_routing_protocol: ebgp
 
 vtep_vvtep_ip: 10.3.3.255/32
 
-# underlay_multicast: true
-# evpn_multicast: true
+underlay_multicast: true
+evpn_multicast: true
 
 bgp_peer_groups: 
   evpn_overlay_core:

--- a/datacenter/domain-d/group_vars/DOMAIN_D.yml
+++ b/datacenter/domain-d/group_vars/DOMAIN_D.yml
@@ -10,8 +10,7 @@ spine:
     loopback_ipv6_pool: 2001:db8:d:1::0/64
     loopback_ipv6_offset: 0
     bgp_as: 65400
-    raw_eos_cli: |
-      agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP='true'
+
   nodes: 
     - name: D-SPINE1
       id: 201 
@@ -56,9 +55,7 @@ l3leaf:
       spanning_tree:
         edge_port:
           bpduguard_default: true
-    # can remove agent KernelFib command, not in tech library
-    raw_eos_cli: |
-      agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP='true'
+          
   node_groups: 
     - group: DOMAIN_D_LA
       bgp_as: 65412

--- a/datacenter/domain-d/group_vars/DOMAIN_D_L3_LEAVES.yml
+++ b/datacenter/domain-d/group_vars/DOMAIN_D_L3_LEAVES.yml
@@ -3,6 +3,7 @@ type: l3leaf
 
 dhcp_relay:
   tunnel_requests_disabled: true
+  mlag_peerlink_requests_disabled: true
 
 # variables used in custom templates
 ## _ prefix = bypass avd schema validation


### PR DESCRIPTION
## Change Summary

**Remove all irrelevant group variables using eos_cli:**
- command only used when ACT was running in AWS
`agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP='true'` was used when ACT was in AWS

- `mlag peer-link requests disabled` now available in `eos_cli_config_gen`
```
dhcp_relay:
  mlag_peerlink_requests_disabled: true
```

## Related Issue(s)

No issues

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code has been rebased from the upstream `main` branch
